### PR TITLE
Remove nc-ddc.org, no longer a US govt URL

### DIFF
--- a/1_govt_urls_full.csv
+++ b/1_govt_urls_full.csv
@@ -5908,7 +5908,6 @@ nazarethboroughpa.com,,,,Local,,Pennsylvania,"Borough of Nazareth, PA -- Note ad
 nbtexas.org,,,,Local,,Texas,"City of New Braunfels, TX -- Note added 6/6/13 18:09",#N/A,6/6/13 18:09
 nbvfc.org,,,,Local,,New Jersey,North Branch Volunteer Fire Company -- Note added 9/16/15 15:48,http://nbvfc.org/,6/6/13 18:08
 nbvillage.com,,,,Local,,Florida,"North Bay Village, FL -- Note added 6/30/15 11:54",http://nbvillage.com/Pages/index,6/6/13 18:08
-nc-ddc.org,,,,State,,North Carolina,NC Council on Developmental Disabilities -- Note added 1/14/14 14:15,http://nc-ddc.org/,6/6/13 18:08
 nc-educationlottery.org,,,,State,,North Carolina,North Carolina Education Lottery -- Note added 6/12/13 14:18,#N/A,6/6/13 18:08
 nc-sco.com,,,,State,,North Carolina,NC State Construction Office -- Note added 9/16/15 13:21,http://www.nc-sco.com/,6/6/13 18:08
 ncabc.com,,,,State,,North Carolina,North Carolina Alcoholic Beverage Control Commission -- Note added 9/11/15 20:30,http://abc.nc.gov/,6/6/13 18:08

--- a/3_govt_urls_state_only.csv
+++ b/3_govt_urls_state_only.csv
@@ -348,7 +348,6 @@ myfwc.com,,State Government,Florida,accepted term,Florida Fish and Wildlife Cons
 mymarianas.com,,State Government,Northern Mariana Islands,accepted term,Travel and Tourism Site for the Northern Mariana Islands -- Note added 6/6/13 19:42,#N/A,6/6/13 19:11
 nationalarchives.gov.vg,,State Government,Virgin Islands,accepted term,"National Archives and Records Management Unit, Government of the Virgin Islands -- Note added 8/18/14 14:03",http://www.nationalarchives.gov.vg/,8/18/14 14:03
 naturalsciences.org,,State Government,North Carolina,accepted term,NC Museum of Natural Sciences -- Note added 11/12/15 15:15,http://naturalsciences.org/index,6/6/13 18:08
-nc-ddc.org,,State Government,North Carolina,accepted term,NC Council on Developmental Disabilities -- Note added 1/14/14 14:15,http://nc-ddc.org/,6/6/13 18:08
 nc-educationlottery.org,,State Government,North Carolina,accepted term,North Carolina Education Lottery -- Note added 6/12/13 14:18,#N/A,6/6/13 18:08
 nc-sco.com,,State Government,North Carolina,accepted term,NC State Construction Office -- Note added 9/16/15 13:21,http://www.nc-sco.com/,6/6/13 18:08
 ncabc.com,,State Government,North Carolina,accepted term,North Carolina Alcoholic Beverage Control Commission -- Note added 9/11/15 20:30,http://abc.nc.gov/,6/6/13 18:08


### PR DESCRIPTION
This URL was added in 2013, but the URL currently points to a Japanese website about what you can and can't feed dogs (see screenshot of the translated page).
<img width="1512" alt="nc-ddc org" src="https://github.com/GSA/govt-urls/assets/1406727/8639801b-eec8-43fa-87b7-a60c8260a0b9">
